### PR TITLE
Move favicon to CDN

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,9 @@
   <link rel="stylesheet" href="{{ "/jekyll-skeleton.css" | prepend: site.url }}">
   <link rel="stylesheet" href="{{ "/icomoon.css" | prepend: site.url }}">
 
-  <link rel="icon" type="image/x-icon" href="{{ "/favicon.png" | prepend: site.url }}" />
+  <link rel="icon" type="image/png" href="https://cdn.lucascantor.com/favicon.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.lucascantor.com/apple-touch-icon.png">
+  <link rel="mask-icon" href="https://cdn.lucascantor.com/safari-pinned-tab.svg" color="#4a86e8">
 
   {% if jekyll.environment == "production" and site.google_analytics %}
   {% include google-analytics.html %}


### PR DESCRIPTION
Add iOS home screen and macOS Safari pinned tab icons