### PR TITLE
Remove Safari mask icon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,6 @@
 
   <link rel="icon" type="image/png" href="https://cdn.lucascantor.com/favicon.png">
   <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.lucascantor.com/apple-touch-icon.png">
-  <link rel="mask-icon" href="https://cdn.lucascantor.com/safari-pinned-tab.svg" color="#4a86e8">
 
   {% if jekyll.environment == "production" and site.google_analytics %}
   {% include google-analytics.html %}


### PR DESCRIPTION
macOS Safari now supports regular favicons
and the mask icon ovrerides them